### PR TITLE
Remove thousands marker for ID fields

### DIFF
--- a/views/islandora_batch.views_default.inc
+++ b/views/islandora_batch.views_default.inc
@@ -141,6 +141,7 @@ function islandora_batch_views_default_views() {
   $handler->display->display_options['fields']['sid']['id'] = 'sid';
   $handler->display->display_options['fields']['sid']['table'] = 'islandora_batch_queue';
   $handler->display->display_options['fields']['sid']['field'] = 'sid';
+  $handler->display->display_options['fields']['sid']['separator'] = '';
   /* Field: Islandora Batch: Item Actions */
   $handler->display->display_options['fields']['actions']['id'] = 'actions';
   $handler->display->display_options['fields']['actions']['table'] = 'islandora_batch_queue';
@@ -465,6 +466,7 @@ function islandora_batch_views_default_views() {
   $handler->display->display_options['fields']['id']['id'] = 'id';
   $handler->display->display_options['fields']['id']['table'] = 'islandora_batch_set';
   $handler->display->display_options['fields']['id']['field'] = 'id';
+  $handler->display->display_options['fields']['id']['separator'] = '';
   /* Field: User: Name */
   $handler->display->display_options['fields']['name']['id'] = 'name';
   $handler->display->display_options['fields']['name']['table'] = 'users';
@@ -523,6 +525,7 @@ function islandora_batch_views_default_views() {
   $handler->display->display_options['fields']['id']['id'] = 'id';
   $handler->display->display_options['fields']['id']['table'] = 'islandora_batch_set';
   $handler->display->display_options['fields']['id']['field'] = 'id';
+  $handler->display->display_options['fields']['id']['separator'] = '';
   /* Field: User: Name */
   $handler->display->display_options['fields']['name']['id'] = 'name';
   $handler->display->display_options['fields']['name']['table'] = 'users';


### PR DESCRIPTION
**JIRA Ticket**: N/A

# What does this Pull Request do?

By default Drupal Views have a comma as the Thousands Marker for integer fields. Set IDs are integers, but they should not have thousands markers. This PR sets the Thousands Marker to _- None -_ for the Batch views.

It's very simple, apologies for not filling everything else out if it is really required.